### PR TITLE
Updated previous-orders look

### DIFF
--- a/resources/assets/sass/components/_previousOrders.scss
+++ b/resources/assets/sass/components/_previousOrders.scss
@@ -20,7 +20,7 @@
         border-collapse: collapse;
     }
 
-    .prev-order {
+    .prev-order-info {
         display: flex;
         flex-wrap: wrap;
         align-items: center;
@@ -55,6 +55,19 @@
         margin: 5px 10px 0px 5px;
     }
 
+    .name {
+        font-weight: 500;
+    }
+    
+    .prev-order {
+        transition: 0.6s;
+    }
+
+    .prev-order:hover {
+        cursor: pointer;
+        background-color: #ead6c0;
+    }
+
     td:nth-child(2) {
         text-align: left;
         padding-left: 40px;
@@ -64,15 +77,16 @@
         text-align: left;
     }
 
-    th:last-child {
+    th:nth-child(4) {
         text-align: center;
     }
 
-    td:last-child {
+    td:nth-child(4) {
         text-align: center;
     }
-    
-    .name {
-        font-weight: 500;
+
+    td:nth-child(5) {
+        text-align: left;
     }
+
 }

--- a/resources/views/previous-orders.blade.php
+++ b/resources/views/previous-orders.blade.php
@@ -15,14 +15,14 @@
         <div class="prev-orders-list">
             <table>
                 <tr>
-                    <th>Product</th>
+                    <th>Product(s)</th>
                     <th>Quantity</th>
                     <th>Total</th>
                     <th>Date Ordered</th>
                 </tr>
-                <tr>
+                <tr class="prev-order" onclick="location.href='{{ route('order.previous') }}'">
                     <td>
-                        <div class="prev-order">
+                        <div class="prev-order-info">
                             <div class="prev-single">
                                 <img class="book-img" src="/images/Anna-Karenina.jpg">
                             </div>
@@ -36,9 +36,9 @@
                     <td>2024-01-05</td>
                 </tr>
 
-                <tr>
+                <tr class="prev-order" onclick="location.href='{{ route('order.previous') }}'">
                     <td>
-                        <div class="prev-order">
+                        <div class="prev-order-info">
                             <div class="prev-single">
                                 <img class="book-img" src="/images/Eugene-Onegin.jpg">
                             </div>

--- a/resources/views/previous-orders.blade.php
+++ b/resources/views/previous-orders.blade.php
@@ -23,27 +23,24 @@
                 <tr>
                     <td>
                         <div class="prev-order">
-                            <img class="book-img" src="/images/Anna-Karenina.jpg">
-                            <div>
-                                <p class="name">Anna Karenina</p>
-                                <small>Price: £12.90</small>
-                                <br>
+                            <div class="prev-single">
+                                <img class="book-img" src="/images/Anna-Karenina.jpg">
+                            </div>
+                            <div class="prev-single">
+                                <img class="book-img" src="/images/Anna-Karenina.jpg">
                             </div>
                         </div>
                     </td>
-                    <td><p>1</p></td>
-                    <td>£12.90</td>
+                    <td><p>2</p></td>
+                    <td>£25.80</td>
                     <td>2024-01-05</td>
                 </tr>
 
                 <tr>
                     <td>
                         <div class="prev-order">
-                            <img class="book-img" src="/images/Eugene-Onegin.jpg">
-                            <div>
-                                <p class="name">Eugene Onegin</p>
-                                <small>Price: £12.90</small>
-                                <br>
+                            <div class="prev-single">
+                                <img class="book-img" src="/images/Eugene-Onegin.jpg">
                             </div>
                         </div>
                     </td>


### PR DESCRIPTION
Can now click on the table rows in /previous to see the full order (routes to order.previous).

Removed extra book details and made table rows change colour when hovered over (w/ pointer cursor).